### PR TITLE
separate: pywavelets and pywavelets-within-python

### DIFF
--- a/plot_benchmark.py
+++ b/plot_benchmark.py
@@ -16,9 +16,9 @@ wavelets = sorted(set(b['wavelet'] for b in data['benchmarks']))
 # Set up the plot
 fig, axes = plt.subplots(2, 1, figsize=(12, 10))
 if include_discrete_wavelets:
-    fig.suptitle('Wasmlets vs Pyodide vs Discrete-Wavelets Performance Comparison')
+    fig.suptitle('Wasmlets vs Pywavelets vs Discrete-Wavelets Performance Comparison')
 else:
-    fig.suptitle('Wasmlets vs Pyodide Performance Comparison')
+    fig.suptitle('Wasmlets vs Pywavelets Performance Comparison')
 
 # Width of each bar and positions of bar groups
 bar_width = 0.1  # Reduced width to fit more bars
@@ -36,18 +36,25 @@ for size_idx, size in enumerate(sizes):
     # Extract timing data for this size
     wasmlets_dec = [next(b['wasmlets']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
     wasmlets_rec = [next(b['wasmlets']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
-    pyodide_dec = [next(b['pyodide']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
-    pyodide_rec = [next(b['pyodide']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
+    pywavelets_wp_dec = [next(b['pywaveletsWithinPython']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
+    pywavelets_wp_rec = [next(b['pywaveletsWithinPython']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
+    pywavelets_dec = [next(b['pywavelets']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
+    pywavelets_rec = [next(b['pywavelets']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
     if include_discrete_wavelets:
         discrete_dec = [next(b['discreteWavelets']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
         # Handle undefined waverec timings for discrete-wavelets
         discrete_rec = [next((b['discreteWavelets']['timings'].get('waverec') or float('nan')) for b in size_data if b['wavelet'] == w) for w in wavelets]
+    else:
+        discrete_dec = [float('nan')] * len(wavelets)
+        discrete_rec = [float('nan')] * len(wavelets)
 
     # Create bars
     ax.bar(r1, wasmlets_dec, width=bar_width, label='Wasmlets Decomposition', color='skyblue')
     ax.bar(r2, wasmlets_rec, width=bar_width, label='Wasmlets Reconstruction', color='lightblue')
-    ax.bar(r3, pyodide_dec, width=bar_width, label='Pyodide Decomposition', color='orange')
-    ax.bar(r4, pyodide_rec, width=bar_width, label='Pyodide Reconstruction', color='wheat')
+    ax.bar(r3, pywavelets_wp_dec, width=bar_width, label='Pywavelets WP Decomposition', color='coral')
+    ax.bar(r4, pywavelets_wp_rec, width=bar_width, label='Pywavelets WP Reconstruction', color='salmon')
+    ax.bar(r3, pywavelets_dec, width=bar_width, label='Pywavelets Decomposition', color='orange')
+    ax.bar(r4, pywavelets_rec, width=bar_width, label='Pywavelets Reconstruction', color='wheat')
     if include_discrete_wavelets:
         ax.bar(r5, discrete_dec, width=bar_width, label='Discrete-Wavelets Decomposition', color='lightgreen')
         # Only plot reconstruction bars for discrete-wavelets if they're not all NaN

--- a/plot_benchmark.py
+++ b/plot_benchmark.py
@@ -37,10 +37,10 @@ for size_idx, size in enumerate(sizes):
     # Extract timing data for this size
     wasmlets_dec = [next(b['wasmlets']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
     wasmlets_rec = [next(b['wasmlets']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
-    pywavelets_wp_dec = [next(b['pywaveletsWithinPython']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
-    pywavelets_wp_rec = [next(b['pywaveletsWithinPython']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
     pywavelets_dec = [next(b['pywavelets']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
     pywavelets_rec = [next(b['pywavelets']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
+    pywavelets_wm_dec = [next(b['pywaveletsWithMarshalling']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
+    pywavelets_wm_rec = [next(b['pywaveletsWithMarshalling']['timings']['waverec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
     if include_discrete_wavelets:
         discrete_dec = [next(b['discreteWavelets']['timings']['wavedec'] for b in size_data if b['wavelet'] == w) for w in wavelets]
         # Handle undefined waverec timings for discrete-wavelets
@@ -50,12 +50,12 @@ for size_idx, size in enumerate(sizes):
         discrete_rec = [float('nan')] * len(wavelets)
 
     # Create bars
-    ax.bar(r1, wasmlets_dec, width=bar_width, label='Wasmlets Decomposition', color='skyblue')
-    ax.bar(r2, wasmlets_rec, width=bar_width, label='Wasmlets Reconstruction', color='lightblue')
-    ax.bar(r3, pywavelets_wp_dec, width=bar_width, label='Pywavelets WP Decomposition', color='coral')
-    ax.bar(r4, pywavelets_wp_rec, width=bar_width, label='Pywavelets WP Reconstruction', color='salmon')
-    ax.bar(r5, pywavelets_dec, width=bar_width, label='Pywavelets Decomposition', color='orange')
-    ax.bar(r6, pywavelets_rec, width=bar_width, label='Pywavelets Reconstruction', color='wheat')
+    ax.bar(r1, wasmlets_dec, width=bar_width, label='Wasmlets Decomp', color='skyblue')
+    ax.bar(r2, wasmlets_rec, width=bar_width, label='Wasmlets Recon', color='lightblue')
+    ax.bar(r3, pywavelets_dec, width=bar_width, label='Pywavelets Decomp', color='coral')
+    ax.bar(r4, pywavelets_rec, width=bar_width, label='Pywavelets Recon', color='salmon')
+    ax.bar(r5, pywavelets_wm_dec, width=bar_width, label='Pywavelets w. Marshalling Decomp', color='orange')
+    ax.bar(r6, pywavelets_wm_rec, width=bar_width, label='Pywavelets w. Marshalling Recon', color='wheat')
     if include_discrete_wavelets:
         ax.bar(r5, discrete_dec, width=bar_width, label='Discrete-Wavelets Decomposition', color='lightgreen')
         # Only plot reconstruction bars for discrete-wavelets if they're not all NaN
@@ -68,7 +68,8 @@ for size_idx, size in enumerate(sizes):
     ax.set_ylabel('Time (ms)')
     ax.set_xticks([r + bar_width*2 for r in range(len(wavelets))])  # Adjusted center position
     ax.set_xticklabels(wavelets)
-    ax.legend()
+    if size == sizes[0]:
+        ax.legend()
     ax.grid(True, alpha=0.3)
 
 plt.tight_layout()

--- a/plot_benchmark.py
+++ b/plot_benchmark.py
@@ -27,6 +27,7 @@ r2 = [x + bar_width for x in r1]
 r3 = [x + bar_width for x in r2]
 r4 = [x + bar_width for x in r3]
 r5 = [x + bar_width for x in r4]
+r6 = [x + bar_width for x in r5]
 
 # Plot for each size
 for size_idx, size in enumerate(sizes):
@@ -53,8 +54,8 @@ for size_idx, size in enumerate(sizes):
     ax.bar(r2, wasmlets_rec, width=bar_width, label='Wasmlets Reconstruction', color='lightblue')
     ax.bar(r3, pywavelets_wp_dec, width=bar_width, label='Pywavelets WP Decomposition', color='coral')
     ax.bar(r4, pywavelets_wp_rec, width=bar_width, label='Pywavelets WP Reconstruction', color='salmon')
-    ax.bar(r3, pywavelets_dec, width=bar_width, label='Pywavelets Decomposition', color='orange')
-    ax.bar(r4, pywavelets_rec, width=bar_width, label='Pywavelets Reconstruction', color='wheat')
+    ax.bar(r5, pywavelets_dec, width=bar_width, label='Pywavelets Decomposition', color='orange')
+    ax.bar(r6, pywavelets_rec, width=bar_width, label='Pywavelets Reconstruction', color='wheat')
     if include_discrete_wavelets:
         ax.bar(r5, discrete_dec, width=bar_width, label='Discrete-Wavelets Decomposition', color='lightgreen')
         # Only plot reconstruction bars for discrete-wavelets if they're not all NaN

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -135,7 +135,7 @@ import time
 import json
 
 # Convert the transferred array to numpy array
-data = np.array(input_data)
+data = np.array(input_data.to_py())
 
 target_duration = ${targetDurationMs / 1000}  # Convert to seconds
 
@@ -335,12 +335,13 @@ const pywaveletsRoundTripDec = async (
 import numpy as np
 import pywt
 
-data = np.array(input_data)
+data = np.array(input_data.to_py())
 
 coeffs = pywt.wavedec(data, '${wavelet}')
 coeffs
         `);
   const coeffs = pyodideResult.toJs();
+  pyodideResult.destroy();
   return coeffs;
 };
 
@@ -356,13 +357,14 @@ import numpy as np
 import pywt
 import pyodide
 
-coeffs = input_coeffs.to_py()
-coeffs = [np.array(c) for c in coeffs]
+coeffs = [np.array(c) for c in input_coeffs.to_py()]
 
 x = pywt.waverec(coeffs, '${wavelet}')
 x
         `);
-  return pyodideResult;
+  const reconstruct = pyodideResult.toJs();
+  pyodideResult.destroy();
+  return reconstruct;
 };
 
 const arraysAreClose = (a: Float64Array, b: Float64Array) => {

--- a/src/benchmark.ts
+++ b/src/benchmark.ts
@@ -42,13 +42,13 @@ async function runBenchmarks() {
         waverec: number;
       };
     };
-    pywaveletsWithinPython: {
+    pywavelets: {
       timings: {
         wavedec: number;
         waverec: number;
       };
     };
-    pywavelets: {
+    pywaveletsWithMarshalling: {
       timings: {
         wavedec: number;
         waverec: number;
@@ -121,9 +121,9 @@ async function runBenchmarks() {
       }
 
       //////////////////////////////////////////////////////////////////////////
-      // Pywavelets-within-python benchmarks
+      // Pywavelets benchmarks
       console.info(
-        `Running pywavelets-within-python benchmarks for size ${size} and wavelet ${wavelet}`
+        `Running pywavelets benchmarks for size ${size} and wavelet ${wavelet}`
       );
 
       pyodide.globals.set("input_data", data);
@@ -160,64 +160,64 @@ waverec_time_elapsed = (end - start) * 1000
 waverec_avg_time = waverec_time_elapsed / num_rec_trials
 
 json.dumps({
-    'pywaveletsWithinPythonDecAvg': wavedec_avg_time,
-    'pywaveletsWithinPythonRecAvg': waverec_avg_time,
+    'pywaveletsDecAvg': wavedec_avg_time,
+    'pywaveletsRecAvg': waverec_avg_time,
     'numDecTrials': num_dec_trials,
     'numRecTrials': num_rec_trials
 })
         `);
       const {
-        pywaveletsWithinPythonDecAvg,
-        pywaveletsWithinPythonRecAvg,
+        pywaveletsDecAvg,
+        pywaveletsRecAvg,
         numDecTrials: pyNumDecTrials,
         numRecTrials: pyNumRecTrials,
       } = JSON.parse(pyodideResult);
       console.info(
-        `wavedec: ${pywaveletsWithinPythonDecAvg}ms (${pyNumDecTrials} trials)`
+        `wavedec: ${pywaveletsDecAvg}ms (${pyNumDecTrials} trials)`
       );
       console.info(
-        `waverec: ${pywaveletsWithinPythonRecAvg}ms (${pyNumRecTrials} trials)`
+        `waverec: ${pywaveletsRecAvg}ms (${pyNumRecTrials} trials)`
       );
       console.info("");
 
       //////////////////////////////////////////////////////////////////////////
-      // Pywavelets benchmarks
+      // Pywavelets-with-marshalling benchmarks
       console.info(
-        `Running pywavelets benchmarks for size ${size} and wavelet ${wavelet}`
+        `Running pywavelets-with-marshalling benchmarks for size ${size} and wavelet ${wavelet}`
       );
-      const startPywaveletsDec = performance.now();
-      let numPywaveletsDecTrials = 0;
-      let pywaveletsCoeffs: any;
-      while (performance.now() - startPywaveletsDec < targetDurationMs) {
-        pywaveletsCoeffs = await pywaveletsRoundTripDec(pyodide, data, wavelet);
-        numPywaveletsDecTrials++;
+      const startPywaveletsWithMarshallingDec = performance.now();
+      let numPywaveletsWithMarshallingDecTrials = 0;
+      let pywaveletsWithMarshallingCoeffs: any;
+      while (performance.now() - startPywaveletsWithMarshallingDec < targetDurationMs) {
+        pywaveletsWithMarshallingCoeffs = await pywaveletsRoundTripDec(pyodide, data, wavelet);
+        numPywaveletsWithMarshallingDecTrials++;
       }
-      const endPywaveletsDec = performance.now();
-      const pywaveletsDecAvg =
-        (endPywaveletsDec - startPywaveletsDec) / numPywaveletsDecTrials;
+      const endPywaveletsWithMarshallingDec = performance.now();
+      const pywaveletsWithMarshallingDecAvg =
+        (endPywaveletsWithMarshallingDec - startPywaveletsWithMarshallingDec) / numPywaveletsWithMarshallingDecTrials;
       console.info(
-        `wavedec: ${pywaveletsDecAvg}ms (${numPywaveletsDecTrials} trials)`
+        `wavedec: ${pywaveletsWithMarshallingDecAvg}ms (${numPywaveletsWithMarshallingDecTrials} trials)`
       );
 
-      const startPywaveletsRec = performance.now();
-      let numPywaveletsRecTrials = 0;
-      let pywaveletsX: any;
-      while (performance.now() - startPywaveletsRec < targetDurationMs) {
-        pywaveletsX = await pywaveletsRoundTripRec(
+      const startPywaveletsWithMarshallingRec = performance.now();
+      let numPywaveletsWithMarshallingRecTrials = 0;
+      let pywaveletsWithMarshallingX: any;
+      while (performance.now() - startPywaveletsWithMarshallingRec < targetDurationMs) {
+        pywaveletsWithMarshallingX = await pywaveletsRoundTripRec(
           pyodide,
-          pywaveletsCoeffs,
+          pywaveletsWithMarshallingCoeffs,
           wavelet
         );
-        numPywaveletsRecTrials++;
+        numPywaveletsWithMarshallingRecTrials++;
       }
-      const endPywaveletsRec = performance.now();
-      const pywaveletsRecAvg =
-        (endPywaveletsRec - startPywaveletsRec) / numPywaveletsRecTrials;
+      const endPywaveletsWithMarshallingRec = performance.now();
+      const pywaveletsWithMarshallingRecAvg =
+        (endPywaveletsWithMarshallingRec - startPywaveletsWithMarshallingRec) / numPywaveletsWithMarshallingRecTrials;
       console.info(
-        `waverec: ${pywaveletsRecAvg}ms (${numPywaveletsRecTrials} trials)`
+        `waverec: ${pywaveletsWithMarshallingRecAvg}ms (${numPywaveletsWithMarshallingRecTrials} trials)`
       );
       console.info("");
-      if (!arraysAreClose(pywaveletsX, x)) {
+      if (!arraysAreClose(pywaveletsWithMarshallingX, x)) {
         throw new Error("Round trip failed");
       }
 
@@ -277,16 +277,16 @@ json.dumps({
             waverec: wasmletsRecAvg,
           },
         },
-        pywaveletsWithinPython: {
-          timings: {
-            wavedec: pywaveletsWithinPythonDecAvg,
-            waverec: pywaveletsWithinPythonRecAvg,
-          },
-        },
         pywavelets: {
           timings: {
             wavedec: pywaveletsDecAvg,
             waverec: pywaveletsRecAvg,
+          },
+        },
+        pywaveletsWithMarshalling: {
+          timings: {
+            wavedec: pywaveletsWithMarshallingDecAvg,
+            waverec: pywaveletsWithMarshallingRecAvg,
           },
         },
         discreteWavelets: {


### PR DESCRIPTION
Here's a crack at doing two separate timings:

(a) pywavelets-within-python: as before, where the timing loop is all within python
(b) pywavelets: where we include round trip setting data, retrieving data

For some reason, wavedec for (a) and (b) is way slower than waverec for (a) and (b). See plot below

@WardBrian could you take a look at what could be going on?

Edit: fixed the graph

![benchmark](https://github.com/user-attachments/assets/4abf8f81-0172-4ff9-9234-a93443379581)
